### PR TITLE
[NONPR-482] Retrieval UI - refreshing results returns those not requested

### DIFF
--- a/app/actors/RetrievalActor.scala
+++ b/app/actors/RetrievalActor.scala
@@ -47,7 +47,6 @@ class RetrievalActor @Inject()(appConfig: AppConfig, pas: ActorService)
     case SubmitMessage(vaultId, archiveId, headerCarrier) =>
       submitRetrievalRequest(vaultId, archiveId)(headerCarrier)
     case StatusMessage(vaultId, archiveId) =>
-//      sender ! pas.pollingActor(vaultId, archiveId).flatMap(aR => aR ? StatusMessage(vaultId, archiveId))
       sender ! pas.eventualPollingActor(vaultId, archiveId)
         .map(aR => aR ? StatusMessage(vaultId, archiveId))
         .recover {case _ => UnknownMessage}

--- a/app/actors/RetrievalActor.scala
+++ b/app/actors/RetrievalActor.scala
@@ -17,9 +17,9 @@
 package actors
 
 import java.util.concurrent.TimeUnit
-import javax.inject.Inject
 
-import akka.actor.{Actor, ActorContext, ActorRef, ActorSystem, Cancellable, Props}
+import javax.inject.Inject
+import akka.actor.{Actor, ActorContext, ActorNotFound, ActorRef, ActorSystem, Cancellable, Props}
 import akka.pattern.ask
 
 import scala.concurrent.duration._
@@ -47,7 +47,11 @@ class RetrievalActor @Inject()(appConfig: AppConfig, pas: ActorService)
     case SubmitMessage(vaultId, archiveId, headerCarrier) =>
       submitRetrievalRequest(vaultId, archiveId)(headerCarrier)
     case StatusMessage(vaultId, archiveId) =>
-      sender ! pas.pollingActor(vaultId, archiveId).flatMap(aR => aR ? StatusMessage(vaultId, archiveId))
+//      sender ! pas.pollingActor(vaultId, archiveId).flatMap(aR => aR ? StatusMessage(vaultId, archiveId))
+      sender ! pas.eventualPollingActor(vaultId, archiveId)
+        .map(aR => aR ? StatusMessage(vaultId, archiveId))
+        .recover {case _ => UnknownMessage}
+
     case _ =>
       logger.warn(s"An unexpected message has been received")
       sender ! Future(UnknownMessage)

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -25,6 +25,7 @@ import akka.stream.Materializer
 import com.google.inject.name.Named
 import play.api.Logger
 import play.api.data.Form
+import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._

--- a/app/views/search_results.scala.html
+++ b/app/views/search_results.scala.html
@@ -39,7 +39,6 @@
                     @search_result(sR._1, sR._2)
                 }
                 <hr>
-                <p>@Messages("search.results.vat.stoed.since.lbl")</p>
             </div>
         </div>
     </div>

--- a/conf/messages
+++ b/conf/messages
@@ -34,7 +34,6 @@ search.button.refresh.lbl=Refresh
 ################################## Search Results ################################################
 search.results.notfound.lbl=No results found
 search.results.check.lbl=Check which submission types are stored
-search.results.vat.stoed.since.lbl=VAT returns have been stored here from 1 April 2014.
 search.results.submitted.lbl=Submitted on
 search.results.results.lbl=results
 search.results.retrieve.lbl=Retrieve

--- a/test/actors/RetrievalActorSpec.scala
+++ b/test/actors/RetrievalActorSpec.scala
@@ -55,8 +55,8 @@ class RetrievalActorSpec() extends TestKit(ActorSystem("MySpec")) with ImplicitS
     }
   }
 
-  "A retrieval actor in response to a StatusMessage" must {
-    "send an UnknownMessage response when no polling actor exists" in {
+  "A retrieval actor" must {
+    "send an UnknownMessage response when no polling actor exists and an UnknownMessage is received" in {
       val mockPollingActorService = mock[ActorService]
       when(mockPollingActorService.pollingActor(any(), any())(any(), any())).thenReturn(Future.failed(new Throwable))
 
@@ -65,6 +65,20 @@ class RetrievalActorSpec() extends TestKit(ActorSystem("MySpec")) with ImplicitS
       Await.result(
         Await.result(
           ask(retrievalActor, UnknownMessage).mapTo[Future[ActorMessage]]
+          , 5 seconds)
+        , 5 seconds) should be(UnknownMessage)
+
+    }
+
+    "send an UnknownMessage response when no polling actor exists and a StatusMessage is received" in {
+      val mockPollingActorService = mock[ActorService]
+      when(mockPollingActorService.eventualPollingActor(any(), any())(any(), any())).thenReturn(Future.failed(new Throwable))
+
+      val retrievalActor: ActorRef = system.actorOf(Props(new RetrievalActor(mockAppConfig, mockPollingActorService)(mockNrsRetrievalConnector)))
+
+      Await.result(
+        Await.result(
+          ask(retrievalActor, StatusMessage(testVaultId, testArchiveId)).mapTo[Future[ActorMessage]]
           , 5 seconds)
         , 5 seconds) should be(UnknownMessage)
 


### PR DESCRIPTION
Do not check for the status of a bundle whose retrieval has not been requested.