### PR TITLE
[NONPR-502] nrs-retrieval-frontend incorrectly expects headerData fields exactly as in sample request

### DIFF
--- a/app/models/NrsSearch.scala
+++ b/app/models/NrsSearch.scala
@@ -30,21 +30,6 @@ object SearchKeys {
 
 case class HeaderData(govClientPublicIP: String, govClientPublicPort: String)
 
-object HeaderData {
-  val headerDataReads: Reads[HeaderData] = (
-    (JsPath \ "Gov-Client-Public-IP").read[String] and
-      (JsPath \ "Gov-Client-Public-Port").read[String]
-    )(HeaderData.apply _)
-
-  val headerDataWrites: Writes[HeaderData] = (
-    (JsPath \ "Gov-Client-Public-IP").write[String] and
-      (JsPath \ "Gov-Client-Public-Port").write[String]
-    )(unlift(HeaderData.unapply))
-
-  implicit val headerDataFormat: Format[HeaderData] =
-    Format(headerDataReads, headerDataWrites)
-}
-
 case class Glacier (
   vaultName: String,
   archiveId: String
@@ -70,7 +55,7 @@ case class NrsSearchResult(
   userSubmissionTimestamp: ZonedDateTime,
   identityData: JsValue,
   userAuthToken: String,
-  headerData: HeaderData,
+  headerData: JsValue,
   searchKeys: SearchKeys,
   nrSubmissionId: String,
   bundle: Bundle,

--- a/test/support/fixtures/NrsSearchFixture.scala
+++ b/test/support/fixtures/NrsSearchFixture.scala
@@ -16,7 +16,7 @@
 
 package support.fixtures
 
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import models._
 import org.joda.time.LocalDate
 import java.time.ZonedDateTime
@@ -25,7 +25,7 @@ trait NrsSearchFixture {
 
   val searchKeys = SearchKeys("vrn", Some(LocalDate.parse("2015-11-01")))
 
-  val headerData = HeaderData("govClientPublicIP", "govClientPublicPort")
+  val headerData: JsValue = Json.parse("""{"SomeAttribute":"SomeValue"}""")
 
   val bundle = Bundle("zip", 123456)
 


### PR DESCRIPTION
Handle headerData as an arbitrary JSON string.