### PR TITLE
[NONPR-657] "authProviderId" hard coded in TxM nonRepudiationStoreSearch event

### DIFF
--- a/app/actors/ActorMessage.scala
+++ b/app/actors/ActorMessage.scala
@@ -16,11 +16,12 @@
 
 package actors
 
+import models.AuthorisedUser
 import uk.gov.hmrc.http.HeaderCarrier
 
 trait ActorMessage
 
-case class SubmitMessage(vaultId: String, archiveId: String, headerCarrier: HeaderCarrier) extends ActorMessage
+case class SubmitMessage(vaultId: String, archiveId: String, headerCarrier: HeaderCarrier, user: AuthorisedUser) extends ActorMessage
 
 case class StatusMessage(vaultId: String, archiveId: String) extends ActorMessage
 

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -82,9 +82,6 @@ class AppConfig @Inject()(val runModeConfiguration: Configuration, val environme
 
   Logger.info(s"Notable events available $notableEvents")
 
-  // todo : this to be replaced on integration with STRIDE
-  val userName = "Susan Smith"
-  
   lazy val nrsStrideRole: String = loadConfig("stride.role.name")
   lazy val strideAuth: Boolean = runModeConfiguration.getBoolean("stride.enabled").getOrElse(false)
   lazy val authHost: String = runModeConfiguration.getString(s"microservice.services.auth.host").getOrElse("none-authHost")

--- a/app/connectors/NrsRetrievalConnector.scala
+++ b/app/connectors/NrsRetrievalConnector.scala
@@ -15,7 +15,7 @@
  */
 
 package connectors
-import models.{NrsSearchResult, SearchQuery}
+import models.{AuthorisedUser, NrsSearchResult, SearchQuery}
 import play.api.libs.ws.WSResponse
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
@@ -23,11 +23,11 @@ import scala.concurrent.Future
 
 trait NrsRetrievalConnector {
 
-  def search(query: SearchQuery)(implicit hc: HeaderCarrier): Future[Seq[NrsSearchResult]]
+  def search(query: SearchQuery, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[Seq[NrsSearchResult]]
 
-  def submitRetrievalRequest(vaultName: String, archiveId: String)(implicit hc: HeaderCarrier): Future[HttpResponse]
+  def submitRetrievalRequest(vaultName: String, archiveId: String, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[HttpResponse]
 
   def statusSubmissionBundle(vaultName: String, archiveId: String)(implicit hc: HeaderCarrier): Future[HttpResponse]
 
-  def getSubmissionBundle(vaultName: String, archiveId: String)(implicit hc: HeaderCarrier): Future[WSResponse]
+  def getSubmissionBundle(vaultName: String, archiveId: String, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[WSResponse]
 }

--- a/app/connectors/NrsRetrievalConnectorImpl.scala
+++ b/app/connectors/NrsRetrievalConnectorImpl.scala
@@ -21,7 +21,7 @@ import play.api.{Environment, Logger}
 import play.api.Mode.Mode
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import config.{AppConfig, Auditable, WSHttpT}
-import models.{NrsSearchResult, SearchQuery}
+import models.{AuthorisedUser, NrsSearchResult, SearchQuery}
 import models.audit.{NonRepudiationStoreDownload, NonRepudiationStoreRetrieve, NonRepudiationStoreSearch}
 import play.api.libs.ws.{WSClient, WSResponse}
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
@@ -37,14 +37,10 @@ class NrsRetrievalConnectorImpl @Inject()(val environment: Environment,
 
   val logger: Logger = Logger(this.getClass)
 
-  override def search(query: SearchQuery)(implicit hc: HeaderCarrier): Future[Seq[NrsSearchResult]] = {
+  override def search(query: SearchQuery, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[Seq[NrsSearchResult]] = {
     logger.info(s"Search for ${query.searchText}")
 
     val path = s"${appConfig.nrsRetrievalUrl}/submission-metadata?${query.searchText}"
-
-    // todo : these values need to come from stride-auth
-    val authProviderId = "authProviderIdValue"
-    val name = "nameValue"
 
     for{
       get <- http.GET[Seq[NrsSearchResult]](path)
@@ -52,26 +48,23 @@ class NrsRetrievalConnectorImpl @Inject()(val environment: Environment,
         .recover{
           case e if e.getMessage.contains("404") => Seq.empty[NrsSearchResult]
           case e if e.getMessage.contains("401") => {
-            auditable.sendDataEvent(NonRepudiationStoreSearch(authProviderId, name, query.searchText, "Unauthorized", path))
+            auditable.sendDataEvent(NonRepudiationStoreSearch(user.authProviderId, user.userName, query.searchText, "Unauthorized", path))
             throw e
           }
         }
-      _ <- auditable.sendDataEvent(NonRepudiationStoreSearch(authProviderId, name, query.searchText, get.seq.headOption.map(_.nrSubmissionId).getOrElse("(Empty)") ,path))
+      _ <- auditable.sendDataEvent(
+        NonRepudiationStoreSearch(user.authProviderId, user.userName, query.searchText, get.seq.headOption.map(_.nrSubmissionId).getOrElse("(Empty)") ,path))
     } yield get
   }
 
-  override def submitRetrievalRequest(vaultName: String, archiveId: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+  override def submitRetrievalRequest(vaultName: String, archiveId: String, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     logger.info(s"Submit a retrieval request for vault: $vaultName, archive: $archiveId")
 
     val path = s"${appConfig.nrsRetrievalUrl}/submission-bundles/$vaultName/$archiveId/retrieval-requests"
 
-    // todo : these values to come from stride-auth
-    val authProviderId = "authProviderIdValue"
-    val name = "nameValue"
-
     for {
       post <- http.POST(path, "", Seq.empty)
-      _ <- auditable.sendDataEvent(NonRepudiationStoreRetrieve(authProviderId, name, vaultName, archiveId,
+      _ <- auditable.sendDataEvent(NonRepudiationStoreRetrieve(user.authProviderId, user.userName, vaultName, archiveId,
         if(post.allHeaders == null) "(Empty)" else post.header("nr-submission-id").getOrElse("(Empty)"), path))
     } yield post
   }
@@ -82,18 +75,14 @@ class NrsRetrievalConnectorImpl @Inject()(val environment: Environment,
     http.HEAD(path)
   }
 
-  override def getSubmissionBundle(vaultName: String, archiveId: String)(implicit hc: HeaderCarrier): Future[WSResponse] = {
+  override def getSubmissionBundle(vaultName: String, archiveId: String, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[WSResponse] = {
     logger.info(s"Get submission bundle for vault: $vaultName, archive: $archiveId")
     val path = s"${appConfig.nrsRetrievalUrl}/submission-bundles/$vaultName/$archiveId"
-
-    // todo : these values to come from stride-auth
-    val authProviderId = "authProviderIdValue"
-    val name = "nameValue"
 
     for{
       get <- ws.url(path).withHeaders(hc.headers ++ hc.extraHeaders ++ hc.otherHeaders: _*).get
       _ <- auditable.sendDataEvent(
-        NonRepudiationStoreDownload(authProviderId, name, vaultName, archiveId, get.header("nr-submission-id").getOrElse("(Empty)"), path))
+        NonRepudiationStoreDownload(user.authProviderId, user.userName, vaultName, archiveId, get.header("nr-submission-id").getOrElse("(Empty)"), path))
     }yield get
   }
 

--- a/app/controllers/StartController.scala
+++ b/app/controllers/StartController.scala
@@ -43,7 +43,7 @@ class StartController @Inject()(
   logger.info(s"appConfig: auth host:port: ${appConfig.authHost}:${appConfig.authPort}")
 
   def showStartPage: Action[AnyContent] = Action.async { implicit request =>
-    authWithStride("Show the start page", { nrUser =>
+    authWithStride("Show the start page", { _ =>
       Future.successful(
         Ok(views.html.start_page())
       )

--- a/app/controllers/Stride.scala
+++ b/app/controllers/Stride.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.AppConfig
-import models.NRUser
+import models.AuthorisedUser
 import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Controller, Request, Result}
@@ -49,14 +49,14 @@ trait Stride extends AuthorisedFunctions with AuthRedirects with Controller with
     }
   }
 
-  def authWithStride(actionName: String, f: NRUser => Future[Result])(
+  def authWithStride(actionName: String, f: AuthorisedUser => Future[Result])(
     implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext, conf: AppConfig): Future[Result] = {
 
     if (appConfig.strideAuth) {
       strideAuthorised {
         case credentials ~ enrolments ~ name =>
           logger.debug(s"$actionName - authorised, enrolments=$enrolments")
-          f(NRUser((name.name.toList ++ name.lastName.toList).mkString(" ")))
+          f(AuthorisedUser((name.name.toList ++ name.lastName.toList).mkString(" "), credentials.providerId))
       }.recover {
         case _: NoActiveSession =>
           logger.debug(s"$actionName - NoActiveSession")
@@ -76,7 +76,7 @@ trait Stride extends AuthorisedFunctions with AuthRedirects with Controller with
       }
     } else {
       logger.debug(s"$actionName - auth switched off")
-      f(NRUser(appConfig.userName))
+      f(AuthorisedUser("Auth disabled", "Auth disabled"))
     }
 
   }

--- a/app/models/AuthorisedUser.scala
+++ b/app/models/AuthorisedUser.scala
@@ -16,8 +16,4 @@
 
 package models
 
-case class NRUser (userName: String)
-
-object NRUser {
-  val user = NRUser("Susan Smith")
-}
+case class AuthorisedUser(userName: String, authProviderId: String)

--- a/app/views/search_page.scala.html
+++ b/app/views/search_page.scala.html
@@ -15,10 +15,10 @@
  *@
 
 @import config.AppConfig
-@import models.NRUser
+@import models.AuthorisedUser
 @import models.Search
 @import uk.gov.hmrc.play.views.html.helpers.{form, input}
-@(searchForm: Form[SearchQuery], user: Option[NRUser] = None, results: Option[Seq[SearchResult]])(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(searchForm: Form[SearchQuery], user: Option[AuthorisedUser] = None, results: Option[Seq[SearchResult]])(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @pageScripts = {
     <script language="JavaScript" type="application/javascript" src="@{routes.Assets.versioned("javascripts/download.js")}"></script>

--- a/app/views/selector_page.scala.html
+++ b/app/views/selector_page.scala.html
@@ -15,12 +15,12 @@
  *@
 
 @import config.AppConfig
-@import models.NRUser
+@import models.AuthorisedUser
 @import models.Selector
 @import views.helpers._
 @import views.html.helpers._
 @import uk.gov.hmrc.play.views.html.helpers.{form}
-@(selectorForm: Form[Selector], user: Option[NRUser] = None)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(selectorForm: Form[Selector], user: Option[AuthorisedUser] = None)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @userName = @{
   user.map(u => Html(u.userName))

--- a/test/controllers/RoutesSpec.scala
+++ b/test/controllers/RoutesSpec.scala
@@ -62,7 +62,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
     "show the search page" when {
       val notableEventType: String = "vat-return"
       "the search returns no results" in {
-        when(mockNrsRetrievalConnector.search(any())(any())).thenReturn(Future.successful(Seq.empty))
+        when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.successful(Seq.empty))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, s"/nrs-retrieval/search/$notableEventType").withFormUrlEncodedBody(
           ("notableEventType", notableEventType)
@@ -75,7 +75,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
       }
 
       "the search returns results" in {
-        when(mockNrsRetrievalConnector.search(any())(any())).thenReturn(Future.successful(Seq(nrsVatSearchResult)))
+        when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.successful(Seq(nrsVatSearchResult)))
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, s"/nrs-retrieval/search/$notableEventType").withFormUrlEncodedBody(
           ("searchKeyName_0", "vrn"),
           ("searchKeyValue_0", "noResults"),
@@ -93,7 +93,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
 
     "show an error page" when {
       "5xx response from the upstream search service" in {
-        when(mockNrsRetrievalConnector.search(any())(any())).thenReturn(Future.failed(new Upstream5xxResponse("Broken", 502, 502)))
+        when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.failed(new Upstream5xxResponse("Broken", 502, 502)))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, "/nrs-retrieval/search").withFormUrlEncodedBody(
           ("action", "search"),
@@ -107,7 +107,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
       }
 
       "4xx response from the upstream search service" in {
-        when(mockNrsRetrievalConnector.search(any())(any())).thenReturn(Future.failed(new Upstream4xxResponse("Broken", 502, 502)))
+        when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.failed(new Upstream4xxResponse("Broken", 502, 502)))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, "/nrs-retrieval/search").withFormUrlEncodedBody(
           ("action", "search"),
@@ -127,14 +127,14 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
       val mockWsResponse = mock[WSResponse]
       when(mockWsResponse.allHeaders).thenReturn(Map("One" -> Seq("Two")))
 
-      when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any())(any())).thenReturn(Future.successful(mockWsResponse))
+      when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.successful(mockWsResponse))
       val result: Option[Future[Result]] = route(app, FakeRequest(GET, "/nrs-retrieval/download/1/2"))
 
       result.map(status(_)) shouldBe Some(OK)
     }
     "show an error page" when {
       "5xx response from the upstream download service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any())(any())).thenReturn(Future.failed(new Upstream5xxResponse("Broken", 502, 502)))
+        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(new Upstream5xxResponse("Broken", 502, 502)))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/download/1/2")))
 
@@ -144,7 +144,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
         }
       }
       "4xx response from the upstream download service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any())(any())).thenReturn(Future.failed(new Upstream4xxResponse("Broken", 502, 502)))
+        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(new Upstream4xxResponse("Broken", 502, 502)))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/download/1/2")))
 
@@ -159,7 +159,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
   "GET /status/:vaultId/:archiveId" should {
     "show an error page" when {
       "5xx response from the upstream status service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any())(any())).thenReturn(Future.failed(new Upstream5xxResponse("Broken", 502, 502)))
+        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(new Upstream5xxResponse("Broken", 502, 502)))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/status/1/2")))
 
@@ -169,7 +169,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
         }
       }
       "4xx response from the upstream status service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any())(any())).thenReturn(Future.failed(new Upstream4xxResponse("Broken", 502, 502)))
+        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(new Upstream4xxResponse("Broken", 502, 502)))
 
         val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/status/1/2")))
 


### PR DESCRIPTION
Finish off the stride auth integration, using the username and provider id in auditing.