### PR TITLE
NONPR-1501 Play framework upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,4 +67,5 @@ lazy val root = (project in file("."))
     parallelExecution in IntegrationTest := false
   )
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+  .disablePlugins(JUnitXmlReportPlugin)
 inConfig(IntegrationTest)(Defaults.itSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 


### PR DESCRIPTION
In this topic https://hmrcdigital.slack.com/archives/C518C88QN/p1596536156340600 similar situation is described, with Jenkins reporting build step as UNSTABLE after upgrading scala to 2.12
There's a suggestion to keep JUnit report plugin disabled https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=176632503