### PR TITLE
[NONPR-2134] ensure the download attribute is set to a valid zip file…

### DIFF
--- a/app/controllers/FormMappings.scala
+++ b/app/controllers/FormMappings.scala
@@ -17,14 +17,15 @@
 package controllers
 
 import models._
-import play.api.data.Form
+import play.api.data.{Form, Mapping}
 import play.api.data.Forms.{longNumber, mapping, optional, text}
 
 object FormMappings {
 
-  val searchResultMapping = mapping(
+  val searchResultMapping: Mapping[SearchResult] = mapping(
     "notableEventDisplayName" -> text,
     "fileDetails" -> text,
+    "fileName" -> text,
     "vaultId" -> text,
     "archiveId" -> text,
     "submissionDateEpochMilli" -> longNumber,

--- a/app/models/SearchResult.scala
+++ b/app/models/SearchResult.scala
@@ -25,6 +25,7 @@ import play.api.libs.json.{Json, OFormat}
 
 case class SearchResult( notableEventDisplayName: String,
                          fileDetails: String,
+                         fileName: String,
                          vaultId: String,
                          archiveId: String,
                          submissionDateEpochMilli: Long,
@@ -44,13 +45,16 @@ class SearchResultUtils @Inject()(appConfig: AppConfig) {
   def fromNrsSearchResult(nrsSearchResult: NrsSearchResult): SearchResult =
     SearchResult(
       appConfig.notableEvents(nrsSearchResult.notableEvent).displayName,
-      filename(nrsSearchResult.nrSubmissionId, nrsSearchResult.bundle.fileType, nrsSearchResult.bundle.fileSize),
+      fileDetails(nrsSearchResult.nrSubmissionId, nrsSearchResult.bundle.fileType, nrsSearchResult.bundle.fileSize),
+      fileName(nrsSearchResult.nrSubmissionId, nrsSearchResult.bundle.fileType),
       nrsSearchResult.glacier.vaultName,
       nrsSearchResult.glacier.archiveId,
       nrsSearchResult.userSubmissionTimestamp.toInstant.toEpochMilli
     )
 
-  private def filename (nrSubmissionId: String, fileType: String, fileSize: Long) =
-    s"$nrSubmissionId.$fileType (${byteCountToDisplaySize(fileSize)})"
+  private def fileName(nrSubmissionId: String, fileType: String) = s"$nrSubmissionId.$fileType"
+
+  private def fileDetails(nrSubmissionId: String, fileType: String, fileSize: Long) =
+    s"${fileName(nrSubmissionId, fileType)} (${byteCountToDisplaySize(fileSize)})"
 
 }

--- a/app/views/search_result.scala.html
+++ b/app/views/search_result.scala.html
@@ -38,7 +38,7 @@
         <br>
         @Messages("search.results.retrieval.info")
       </span>
-      <a class="retrieval-complete button--secondary" role="button" aria-hidden="true" href="@{s"/nrs-retrieval/download/${searchResult.vaultId}/${searchResult.archiveId}"}" download="@searchResult.fileDetails">@Messages("search.results.download.lbl") @searchResult.linkText @timeSubmitted</a>
+      <a class="retrieval-complete button--secondary" role="button" aria-hidden="true" href="@{s"/nrs-retrieval/download/${searchResult.vaultId}/${searchResult.archiveId}"}" download="@searchResult.fileName">@Messages("search.results.download.lbl") @searchResult.linkText @timeSubmitted</a>
       <a class="start-retrieval" data-index="@{index}" data-vault-id="@{searchResult.vaultId}" data-archive-id="@{searchResult.archiveId}" href="#">@Messages("search.results.retrieve.lbl") @searchResult.linkText @timeSubmitted</a>
     </p>
     <p>

--- a/test/controllers/SearchControllerControllerSpec.scala
+++ b/test/controllers/SearchControllerControllerSpec.scala
@@ -18,20 +18,28 @@ package controllers
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.Materializer
+import akka.util.Timeout
 import config.AppConfig
 import connectors.NrsRetrievalConnector
+import controllers.FormMappings.searchForm
+import models.{AuthorisedUser, SearchQuery}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.AnyContentAsJson
+import play.api.test.Helpers.contentAsString
 import play.api.test.{FakeRequest, StubControllerComponentsFactory}
 import play.api.{Configuration, Environment}
 import support.fixtures.{NrsSearchFixture, SearchFixture, StrideFixture}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.Future
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
 
 class SearchControllerControllerSpec extends UnitSpec
   with WithFakeApplication
@@ -39,21 +47,28 @@ class SearchControllerControllerSpec extends UnitSpec
   with SearchFixture
   with NrsSearchFixture
   with StrideFixture
+  with Status
   with StubControllerComponentsFactory {
 
-  private val jsonBody: JsValue = Json.parse("""{"searchKeyName_0": "someValue", "searchKeyValue_0": "someValue", "notableEventType": "vat-return"}""")
-  private implicit val fakeRequest: FakeRequest[AnyContentAsJson] = FakeRequest("GET", "/").withJsonBody(jsonBody)
+  private val notableEventType = "vat-return"
+  private val jsonBody: JsValue =
+    Json.parse("""{"searchKeyName_0": "someValue", "searchKeyValue_0": "someValue", "notableEventType": """" + notableEventType + """"}""")
 
   private val env = Environment.simple()
   private val configuration = Configuration.load(env)
 
-  implicit val appConfig: AppConfig = new AppConfig(configuration, env, new ServicesConfig(configuration))
+  private implicit val fakeRequest: FakeRequest[AnyContentAsJson] = FakeRequest("GET", "/").withJsonBody(jsonBody)
+  private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+  private implicit val appConfig: AppConfig = new AppConfig(configuration, env, new ServicesConfig(configuration))
+  private implicit val timeout: Timeout = new Timeout(new FiniteDuration(2, SECONDS))
+  private implicit val mockSystem: ActorSystem = mock[ActorSystem]
+  private implicit val mockMaterializer: Materializer = mock[Materializer]
+
   private val mockActorRef = mock[ActorRef]
   private val mockNRC = mock[NrsRetrievalConnector]
-  implicit val mockSystem: ActorSystem = mock[ActorSystem]
-  implicit val mockMaterializer: Materializer = mock[Materializer]
-  private val searchPage = fakeApplication.injector.instanceOf[views.html.search_page]
-  private val errorPage = fakeApplication.injector.instanceOf[views.html.error_template]
+
+  private lazy val searchPage = fakeApplication.injector.instanceOf[views.html.search_page]
+  private lazy val errorPage = fakeApplication.injector.instanceOf[views.html.error_template]
 
   private class TestControllerAuthSearch(stubbedRetrievalResult: Future[_])
     extends SearchController(mockActorRef, authConnector, mockNRC, searchResultUtils, stubMessagesControllerComponents(), searchPage, errorPage) {
@@ -66,18 +81,33 @@ class SearchControllerControllerSpec extends UnitSpec
 
   "showSearchPage" should {
     "return 200" in {
-      val result = controller.showSearchPage(notableEventType = "vat-return")(fakeRequest)
-      status(result) shouldBe Status.OK
+      val result = controller.showSearchPage(notableEventType = notableEventType)(fakeRequest)
+      status(result) shouldBe OK
+    }
+  }
+
+  "submitSearchPage" should {
+    "display results with a download attribute containing a valid zip file name" when {
+      "results are returned" in {
+        when(mockNRC.search(any[SearchQuery], any[AuthorisedUser])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(Seq(nrsVatSearchResult)))
+
+        val eventualResult =
+          controller.submitSearchPage(notableEventType = notableEventType)(
+            fakeRequest.withFormUrlEncodedBody("searchText" -> "someSearchText", "notableEventType" -> notableEventType))
+        status(eventualResult) shouldBe OK
+        val body = contentAsString(eventualResult)
+        body.contains(s"""download="$nrSubmissionId.zip"""") shouldBe true
+      }
     }
   }
 
   "searchForm" should {
     "return no errors for valid data" in {
-      val postData = Json.obj("searchText" -> "someSearchText",
-        "notableEventType" -> "vat-return")
-      val validatedForm = FormMappings.searchForm.bind(postData)
-      validatedForm.errors shouldBe empty
+      val postData = Json.obj("searchText" -> "someSearchText", "notableEventType" -> notableEventType)
+      searchForm.bind(postData, Int.MaxValue).errors shouldBe empty
     }
+
     "create a header carrier with X-API-Key when one exists in config" in {
       controller.hc.extraHeaders should contain("X-API-Key" -> appConfig.xApiKey)
     }

--- a/test/support/fixtures/SearchFixture.scala
+++ b/test/support/fixtures/SearchFixture.scala
@@ -18,7 +18,6 @@ package support.fixtures
 
 import config.AppConfig
 import models.{SearchResult, SearchResultUtils}
-import play.api.libs.json.{JsValue, Json}
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -30,11 +29,9 @@ trait SearchFixture extends NrSubmissionId {
 
   val searchResultUtils: SearchResultUtils = new SearchResultUtils(appConfig)
 
-  val searchFormJson: JsValue = Json.parse("""{"searchText":"aVal"}""")
+  private val fileName = s"$nrSubmissionId.zip"
 
-  val fileSize = 123456L
-  val vatSearchResult = SearchResult("VAT return", s"$nrSubmissionId.zip (120 KB)", "12345", "1234567890", 1511773625L, None)
-  val vatRegSearchResult = SearchResult("VAT registration", s"$nrSubmissionId.zip (120 KB)", "12345", "1234567890", 1511773625L, None)
-
+  val vatSearchResult: SearchResult =
+    SearchResult("VAT return", s"$fileName (120 KB)", fileName, "12345", "1234567890", 1511773625L, None)
 }
 


### PR DESCRIPTION
… name

This is a fix for NONPR-2134 which will ensure that in the event that the downloaded submission file is correctly suffixed as a `zip` in the event that the frontend relies on the `download` attribute to name the file - this seems to have started happening after the recent `scala` and `play` upgrades. 

```
sbt test
...
[info] Run completed in 11 seconds, 720 milliseconds.
[info] Total number of tests run: 54
[info] Suites: completed 13, aborted 0
[info] Tests: succeeded 54, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 54, Failed 0, Errors 0, Passed 54
```

```
sbt it:test 
...
[info] Run completed in 19 seconds, 940 milliseconds.
[info] Total number of tests run: 21
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 21, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 21, Failed 0, Errors 0, Passed 21
```

acceptance tests
```
[info] ScalaTest
[info] Run completed in 3 minutes, 39 seconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 24, Failed 0, Errors 0, Passed 24
[success] Total time: 233 s (03:53), completed 25-Jun-2021 16:45:03
```


I also performed a manual test running services locally against `QA` to ensure the downloaded file is correctly suffixed. Files are downloaded with content. 

