### PR TITLE
[NONPR-2134] handle errors on download

### DIFF
--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -16,8 +16,6 @@
 
 package controllers
 
-import java.util.concurrent.TimeUnit
-
 import actors._
 import akka.actor.ActorRef
 import akka.pattern.{AskTimeoutException, ask}
@@ -26,18 +24,20 @@ import com.google.inject.name.Named
 import config.AppConfig
 import connectors.NrsRetrievalConnector
 import controllers.FormMappings._
-import javax.inject.{Inject, Singleton}
 import models._
 import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, HttpException}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.{error_template, search_page}
+
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import views.html.{error_template, search_page}
 
 @Singleton
 class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: ActorRef,
@@ -93,10 +93,9 @@ class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: Actor
     })
   }
 
-  private def doSearch(search: SearchQuery, user: AuthorisedUser)(implicit hc: HeaderCarrier) = {
+  private def doSearch(search: SearchQuery, user: AuthorisedUser)(implicit hc: HeaderCarrier) =
     nrsRetrievalConnector.search(search, user)
       .map(fNSR => fNSR.map(nSR => searchResultUtils.fromNrsSearchResult(nSR)))
-  }
 
   def refresh(vaultName: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
     logger.info(s"Refresh the result $vaultName, $archiveId on request $request")
@@ -122,18 +121,15 @@ class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: Actor
 
     nrsRetrievalConnector.statusSubmissionBundle(vaultName, archiveId).map { response =>
       response.status match {
-        case OK => {
+        case OK =>
           logger.info(s"Retrieval request complete for vault $vaultName, archive $archiveId")
           Ok(CompletionStatus.complete)
-        }
-        case NOT_FOUND => {
+        case NOT_FOUND =>
           logger.info(s"Status check for vault $vaultName, archive $archiveId returned 404")
           Ok(CompletionStatus.incomplete)
-        }
-        case _ => {
+        case _ =>
           logger.info(s"Retrieval request failed for vault $vaultName, archive $archiveId")
           Ok(CompletionStatus.failed)
-        }
       }
     } recoverWith {
       case e: Exception =>
@@ -145,10 +141,9 @@ class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: Actor
   def doAjaxRetrieve(vaultName: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
     logger.info(s"Request retrieval for $vaultName, $archiveId")
     authWithStride("Download", { user =>
-      ask(retrievalActor, SubmitMessage(vaultName, archiveId, hc, user)).mapTo[Future[ActorMessage]].flatMap(identity).map {
-        case _ =>
-          logger.info(s"Retrieval accepted for $vaultName, $archiveId")
-          Accepted(CompletionStatus.incomplete)
+      ask(retrievalActor, SubmitMessage(vaultName, archiveId, hc, user)).mapTo[Future[ActorMessage]].flatMap(identity).map { _ =>
+        logger.info(s"Retrieval accepted for $vaultName, $archiveId")
+        Accepted(CompletionStatus.incomplete)
       } recoverWith {
         case e: AskTimeoutException =>
           logger.info(s"Retrieval is still in progress for $vaultName, $archiveId, $e")
@@ -158,14 +153,22 @@ class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: Actor
   }
 
   def download(vaultName: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
-    logger.info(s"Request download of $vaultName, $archiveId")
+    val messagePrefix = s"Request download of $vaultName, $archiveId"
+
+    logger.info(messagePrefix)
+
     authWithStride("Download", { user =>
       nrsRetrievalConnector.getSubmissionBundle(vaultName, archiveId, user).map { response =>
-        logger.info(s"Download of $vaultName, $archiveId")
-        Ok(response.bodyAsBytes).withHeaders(mapToSeq(response.headers): _*)
-      }.recoverWith { case e =>
-        logger.info(s"Download of $vaultName, $archiveId failed with $e")
-        Future(Ok(errorPage(request.messages("error.page.title"), request.messages("error.page.heading"), request.messages("error.page.message"))))
+        val errorMessage = s"$messagePrefix received unexpected response status: ${response.status.toString}"
+
+        response.status match {
+          case status if status >= MULTIPLE_CHOICES => throw new HttpException(errorMessage, status)
+          case status =>
+            // log response size rather than the content as this might contain sensitive information
+            val bytes = response.bodyAsBytes
+            logger.info(s"$messagePrefix received status: [$status] and ${bytes.size} bytes from upstream.")
+            Ok(bytes).withHeaders(mapToSeq(response.headers): _*)
+        }
       }
     })
   }

--- a/it/uk/gov/hmrc/nrsretrievalfrontend/stubs/NrsRetrievalStubs.scala
+++ b/it/uk/gov/hmrc/nrsretrievalfrontend/stubs/NrsRetrievalStubs.scala
@@ -48,8 +48,8 @@ object NrsRetrievalStubs {
   def verifySearchWithXApiKeyHeader(): Unit =
     verify(getRequestedFor(urlEqualTo(searchPath)).withHeader(xApiKeyHeader, equalToXApiKey))
 
-  def givenGetSubmissionBundlesReturns(status: Int): StubMapping =
-    stubFor(get(urlEqualTo(submissionBundlesPath)).willReturn(aResponse().withStatus(status)))
+  def givenGetSubmissionBundlesReturns(status: Int, body: String = ""): StubMapping =
+    stubFor(get(urlEqualTo(submissionBundlesPath)).willReturn(aResponse().withStatus(status).withBody(body)))
 
   def verifyGetSubmissionBundlesWithXApiKeyHeader(): Unit =
     verify(getRequestedFor(urlEqualTo(submissionBundlesPath)).withHeader(xApiKeyHeader, equalToXApiKey))

--- a/test/controllers/RoutesSpec.scala
+++ b/test/controllers/RoutesSpec.scala
@@ -20,9 +20,12 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import play.api.i18n.Messages
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.ahc.{AhcWSResponse, StandaloneAhcWSResponse}
+import play.api.libs.ws.ahc.cache.CacheableResponse
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClientConfig
 import support.fixtures.NrsSearchFixture
 import support.{BaseSpec, GuiceAppSpec}
 import uk.gov.hmrc.http.UpstreamErrorResponse
@@ -53,18 +56,20 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
 
       val text: String = result.map(contentAsString(_)).get
       text should include(Messages(s"search.page.$notableEventType.header.lbl"))
-      text should not include(Messages("search.results.notfound.lbl"))
-      text should not include(Messages("search.results.results.lbl"))
+      text should not include Messages("search.results.notfound.lbl")
+      text should not include Messages("search.results.results.lbl")
     }
   }
 
   "POST /search" should {
+    val notableEventType = "vat-return"
+    val request = FakeRequest(POST, s"/nrs-retrieval/search/$notableEventType")
+
     "show the search page" when {
-      val notableEventType: String = "vat-return"
       "the search returns no results" in {
         when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.successful(Seq.empty))
 
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, s"/nrs-retrieval/search/$notableEventType").withFormUrlEncodedBody(
+        val result: Option[Future[Result]] = route(app, addToken(request.withFormUrlEncodedBody(
           ("notableEventType", notableEventType)
         )))
 
@@ -76,7 +81,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
 
       "the search returns results" in {
         when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.successful(Seq(nrsVatSearchResult)))
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, s"/nrs-retrieval/search/$notableEventType").withFormUrlEncodedBody(
+        val result: Option[Future[Result]] = route(app, addToken(request.withFormUrlEncodedBody(
           ("searchKeyName_0", "vrn"),
           ("searchKeyValue_0", "noResults"),
           ("notableEventType", notableEventType)
@@ -86,99 +91,83 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
 
         val text: String = result.map(contentAsString(_)).get
         text should include(Messages(s"search.page.$notableEventType.header.lbl"))
-        text should not include (Messages("search.results.notfound.lbl"))
+        text should not include Messages("search.results.notfound.lbl")
         text should include(Messages("search.results.results.lbl"))
       }
     }
 
-    "show an error page" when {
-      "5xx response from the upstream search service" in {
-        when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.failed(UpstreamErrorResponse("Broken", 502, 502)))
+    Seq(BAD_REQUEST, BAD_GATEWAY).foreach{ statusCode =>
+      "show an error page" when {
+        s"$statusCode response from the upstream search service" in {
+          when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(
+            Future.failed(UpstreamErrorResponse("Broken", statusCode, statusCode)))
 
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, "/nrs-retrieval/search").withFormUrlEncodedBody(
-          ("action", "search"),
-          ("query.searchText", "results")
-        )))
+          val result: Option[Future[Result]] = route(app, addToken(request.withFormUrlEncodedBody(
+            ("action", "search"),
+            ("query.searchText", "results")
+          )))
 
-        result.get.onComplete {
-          case Failure(e) if e.isInstanceOf[UpstreamErrorResponse] => succeed
-          case _ => fail
-        }
-      }
-
-      "4xx response from the upstream search service" in {
-        when(mockNrsRetrievalConnector.search(any(), any())(any())).thenReturn(Future.failed(UpstreamErrorResponse("Broken", 502, 502)))
-
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(POST, "/nrs-retrieval/search").withFormUrlEncodedBody(
-          ("action", "search"),
-          ("query.searchText", "results")
-        )))
-
-        result.get.onComplete {
-          case Failure(e) if e.isInstanceOf[UpstreamErrorResponse] => succeed
-          case _ => fail
+          result.get.onComplete {
+            case Failure(e: UpstreamErrorResponse) if e.statusCode == statusCode => succeed
+            case _ => fail
+          }
         }
       }
     }
   }
 
   "GET /download/:vaultId/:archiveId" should {
-    "return OK" in {
+    val request = FakeRequest(GET, "/nrs-retrieval/download/1/2")
+
+    "return OK and the file contents" in {
+      val fileContents = "file contents"
       val mockWsResponse = mock[WSResponse]
       when(mockWsResponse.headers).thenReturn(Map("One" -> Seq("Two")))
 
-      when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.successful(mockWsResponse))
-      val result: Option[Future[Result]] = route(app, FakeRequest(GET, "/nrs-retrieval/download/1/2"))
+      val response =
+        AhcWSResponse(
+          StandaloneAhcWSResponse(
+            CacheableResponse(OK, "http://www.test.com", fileContents, mock[AsyncHttpClientConfig])))
+
+      when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.successful(response))
+      val result: Option[Future[Result]] = route(app, request)
 
       result.map(status(_)) shouldBe Some(OK)
+      result.map(contentAsString(_)) shouldBe Some(fileContents)
     }
-    "show an error page" when {
-      "5xx response from the upstream download service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(UpstreamErrorResponse("Broken", 502, 502)))
 
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/download/1/2")))
+    Seq(BAD_REQUEST, BAD_GATEWAY).foreach { statusCode =>
+      "error" when {
+        s"$statusCode response from the upstream download service" in {
+          when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(
+            Future.failed(UpstreamErrorResponse("Broken", statusCode, statusCode)))
 
-        result.get.onComplete {
-          case Failure(e) if e.isInstanceOf[UpstreamErrorResponse] => succeed
-          case _ => fail
-        }
-      }
-      "4xx response from the upstream download service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(UpstreamErrorResponse("Broken", 502, 502)))
+          val result: Option[Future[Result]] = route(app, addToken(request))
 
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/download/1/2")))
-
-        result.get.onComplete {
-          case Failure(e) if e.isInstanceOf[UpstreamErrorResponse] => succeed
-          case _ => fail
+          result.get.onComplete {
+            case Failure(e: UpstreamErrorResponse) if e.statusCode == statusCode => succeed
+            case _ => fail
+          }
         }
       }
     }
   }
 
-  "GET /status/:vaultId/:archiveId" should {
-    "show an error page" when {
-      "5xx response from the upstream status service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(UpstreamErrorResponse("Broken", 502, 502)))
+  Seq(BAD_REQUEST, BAD_GATEWAY).foreach { statusCode =>
+    "GET /status/:vaultId/:archiveId" should {
+      "show an error page" when {
+        s"$statusCode response from the upstream status service" in {
+          when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(
+            Future.failed(UpstreamErrorResponse("Broken", statusCode, statusCode)))
 
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/status/1/2")))
+          val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/status/1/2")))
 
-        result.get.onComplete {
-          case Failure(e) if e.isInstanceOf[UpstreamErrorResponse] => succeed
-          case _ => fail
-        }
-      }
-      "4xx response from the upstream status service" in {
-        when(mockNrsRetrievalConnector.getSubmissionBundle(any(), any(), any())(any())).thenReturn(Future.failed(UpstreamErrorResponse("Broken", 502, 502)))
-
-        val result: Option[Future[Result]] = route(app, addToken(FakeRequest(GET, "/nrs-retrieval/status/1/2")))
-
-        result.get.onComplete {
-          case Failure(e) if e.isInstanceOf[UpstreamErrorResponse] => succeed
-          case _ => fail
+          result.get.onComplete {
+            case Failure(e: UpstreamErrorResponse) if e.statusCode == statusCode => succeed
+            case _ => fail
+          }
         }
       }
     }
   }
-
 }


### PR DESCRIPTION
Similar to https://github.com/hmrc/nrs-retrieval/pull/36, this change handles and logs errors for the file download so that we can investigate the current issue better.

A local manual test shows that user-facing behaviour is unchanged but we now see an error message logged when the stub is stopped.

```
sbt test
...
[info] ScalaTest
[info] Run completed in 11 seconds, 71 milliseconds.
[info] Total number of tests run: 54
[info] Suites: completed 13, aborted 0
[info] Tests: succeeded 54, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

```
sbt it:test
...
[info] ScalaTest
[info] Run completed in 20 seconds, 556 milliseconds.
[info] Total number of tests run: 27
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 27, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 27, Failed 0, Errors 0, Passed 27
[success] Total time: 22 s, completed 30-Jun-2021 09:31:00
```

acceptance tests:
```
[info] ScalaTest
[info] Run completed in 3 minutes, 21 seconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 24, Failed 0, Errors 0, Passed 24
```