### PR TITLE
[NONPR-2134] download with http verbs

### DIFF
--- a/app/config/HttpGetRaw.scala
+++ b/app/config/HttpGetRaw.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.http.HttpVerbs.{GET => GET_VERB}
+import uk.gov.hmrc.http._
+import uk.gov.hmrc.http.hooks.HttpHooks
+import uk.gov.hmrc.http.logging.ConnectionTracing
+import uk.gov.hmrc.play.http.ws.{WSHttpResponse, WSRequest}
+
+import java.net.URL
+import scala.concurrent.{ExecutionContext, Future}
+
+trait GetRawHttpTransport {
+  def doGetRaw(url: String, headers: Seq[(String, String)])
+            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[WSResponse]
+}
+
+trait CoreGetRaw {
+  def GETRaw(url: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[WSResponse]
+}
+
+trait WSGetRaw extends WSRequest with CoreGetRaw with GetRawHttpTransport {
+  override def doGetRaw(url: String, headers: Seq[(String, String)])
+                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[WSResponse] =
+    buildRequest(url, headers).get()
+}
+
+trait HttpGetRaw extends CoreGetRaw with GetRawHttpTransport with HttpVerb with ConnectionTracing with HttpHooks {
+
+  override def GETRaw(url: String, headers: Seq[(String, String)])
+                     (implicit  hc: HeaderCarrier, ec: ExecutionContext): Future[WSResponse] =
+    withTracing(GET_VERB, url) {
+      val httpResponse = doGetRaw(url, headers)
+      val wsHttpResponse = httpResponse.map(WSHttpResponse(_))
+
+      executeHooks(GET_VERB, new URL(url), headers, None, wsHttpResponse)
+      mapErrors(GET_VERB, url, wsHttpResponse)
+      httpResponse
+    }
+}
+

--- a/app/config/HttpHead.scala
+++ b/app/config/HttpHead.scala
@@ -31,9 +31,6 @@ trait HeadHttpTransport {
             (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse]
 }
 
-trait HttpTransport extends GetHttpTransport {
-}
-
 trait CoreHead {
   def HEAD[A](url: String, headers: Seq[(String, String)])(implicit rds: HttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
 
@@ -45,7 +42,7 @@ trait WSHead extends WSRequest with CoreHead with HeadHttpTransport {
   override def doHead(url: String, headers: Seq[(String, String)])
                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     buildRequest(url, headers).head().map(WSHttpResponse(_))
-  }
+}
 
 trait HttpHead extends CoreHead with HeadHttpTransport with HttpVerb with ConnectionTracing with HttpHooks {
 

--- a/app/config/WSHttp.scala
+++ b/app/config/WSHttp.scala
@@ -56,6 +56,7 @@ trait WSHttpT extends HttpGet with WSGet
   with HttpDelete with WSDelete
   with HttpPatch with WSPatch
   with HttpHead with WSHead
+  with HttpGetRaw with WSGetRaw
 
 @Singleton
 class WSHttp @Inject() (val environment: Environment, val runModeConfig: Configuration, val appNameConfig: Configuration, val wsClient: WSClient)

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -175,5 +175,4 @@ class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: Actor
 
   private def mapToSeq(sourceMap: Map[String, Seq[String]]): Seq[(String, String)] =
     sourceMap.keys.flatMap(k => sourceMap(k).map(v => (k, v))).toSeq
-
 }


### PR DESCRIPTION
As the call from this service to the backend endpoint `HEAD /submission-bundles/:vaultId/:archiveId` works in `MDTP` but the corresponding call to `GET /submission-bundles/:vaultId/:archiveId` does not, this change uses the same approach for the `GET` as the `HEAD` to see whether this fixes the download issue.

A manual test shows that the download still works when services are run locally.

If this works in `MDTP` then we should at least see logging output from the back end service for a download attempt.

However it might still be necessary to implement the same steps in the backend service before the end to end  functionality is fixed.

```
sbt test
...
[info] ScalaTest
[info] Run completed in 11 seconds, 608 milliseconds.
[info] Total number of tests run: 53
[info] Suites: completed 13, aborted 0
[info] Tests: succeeded 53, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 53, Failed 0, Errors 0, Passed 53
[success] Total time: 14 s, completed 30-Jun-2021 14:42:59
```

```
sbt it:test
...
[info] ScalaTest
[info] Run completed in 21 seconds, 614 milliseconds.
[info] Total number of tests run: 27
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 27, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 27, Failed 0, Errors 0, Passed 27
```

acceptance tests:
```
[info] ScalaTest
[info] Run completed in 3 minutes, 17 seconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 24, Failed 0, Errors 0, Passed 24
[success] Total time: 214 s (03:34), completed 30-Jun-2021 14:41:18
```