### PR TITLE
[NONPR-2078] fix broken RoutesSpec

### DIFF
--- a/test/controllers/RoutesSpec.scala
+++ b/test/controllers/RoutesSpec.scala
@@ -53,8 +53,8 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
 
       val text: String = result.map(contentAsString(_)).get
       text should include(Messages(s"search.page.$notableEventType.header.lbl"))
-      text should not include(Messages("search.results.notfound.lbl"))
-      text should not include(Messages("search.results.results.lbl"))
+      text should not include Messages("search.results.notfound.lbl")
+      text should not include Messages("search.results.results.lbl")
 
     }
   }
@@ -87,7 +87,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
 
         val text: String = result.map(contentAsString(_)).get
         text should include(Messages(s"search.page.$notableEventType.header.lbl"))
-        text should not include (Messages("search.results.notfound.lbl"))
+        text should not include Messages("search.results.notfound.lbl")
         text should include(Messages("search.results.results.lbl"))
       }
     }
@@ -154,6 +154,7 @@ class RoutesSpec extends GuiceAppSpec with BaseSpec with NrsSearchFixture {
         }
       }
     }
+  }
 
 
     "GET /status/:vaultId/:archiveId" should {


### PR DESCRIPTION
```
sbt test
...
[info] ScalaTest
[info] Run completed in 12 seconds, 561 milliseconds.
[info] Total number of tests run: 55
[info] Suites: completed 13, aborted 0
[info] Tests: succeeded 55, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 55, Failed 0, Errors 0, Passed 55
```
