### PR TITLE
Nonpr 2231

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ The endpoint functions as follows:
     Given I am a user authenticated via Stride but without the enrolment nrs_digital_investigator
     When I navigate to /nrs-retrieval/test-only/check-authorisation
     Then a call is made to the nrs-retrieval endpoint /test-only/check-authorisation
-    And content is served which shows that nrs-retrieval has deduced that I am authenticated in Stride but not authorised for NRS
+    And content is served which shows that nrs-retrieval has deduced that I am authenticated via Stride but not authorised for NRS
 
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,37 @@ You should then be able to start the application using:
 
 ### Test-only endpoints
 
-There is a test-only page that can be used to validate the download functionality and the contents of an available 
-zip to download.
+To use the test-only endpoints, run the service using the `./run-with-test-only-endpoints.sh` script.
 
-To use this, run the service using the `./run-with-test-only-endpoints.sh` script. 
 
-Navigate to
+`GET  /nrs-retrieval/test-only/validate-download`
 
-  `GET  /nrs-retrieval/test-only/validate-download`
+This test-only endpoint serves an HTML page that can be used to validate the contents of an available zip to download.
 
-and enter the archive name and vault id of the download to verify.
+To use, submit the archive name and vault id of the download to verify.
+
+
+`GET  /nrs-retrieval/test-only/check-authorisation`
+
+This test-only endpoint serves an HTML page that can be used to demonstrate that the backend `nrs-retrieval` service can be integrated with stride auth.
+
+It was added as part of a spike to show whether we can add security in depth to `nrs-retrieval` and we anticipate that once this is done the endpoint will be removed.
+
+The endpoint functions as follows:
+
+    Given I am a user authenticated via Stride with the enrolment nrs_digital_investigator
+    When I navigate to /nrs-retrieval/test-only/check-authorisation
+    Then a call is made to the nrs-retrieval endpoint /test-only/check-authorisation
+    And content is served which shows that nrs-retrieval has deduced that I am authenticated via Stride and authorised for NRS
+
+    Given I am a user not authenticated via Stride
+    When I navigate to /nrs-retrieval/test-only/check-authorisation
+    Then a call is made to the nrs-retrieval endpoint /test-only/check-authorisation
+    And content is served which shows that nrs-retrieval has deduced that I am not authenticated via Stride
+
+    Given I am a user authenticated via Stride but without the enrolment nrs_digital_investigator
+    When I navigate to /nrs-retrieval/test-only/check-authorisation
+    Then a call is made to the nrs-retrieval endpoint /test-only/check-authorisation
+    And content is served which shows that nrs-retrieval has deduced that I am authenticated in Stride but not authorised for NRS
+
+

--- a/app/connectors/testonly/TestOnlyNrsRetrievalConnector.scala
+++ b/app/connectors/testonly/TestOnlyNrsRetrievalConnector.scala
@@ -24,4 +24,6 @@ import scala.concurrent.Future
 
 trait TestOnlyNrsRetrievalConnector {
   def validateDownload(vaultName: String, archiveId: String, user: AuthorisedUser)(implicit hc: HeaderCarrier): Future[ValidateDownloadResult]
+
+  def checkAuthorisation()(implicit hc: HeaderCarrier): Future[Boolean]
 }

--- a/app/connectors/testonly/TestOnlyNrsRetrievalConnectorImpl.scala
+++ b/app/connectors/testonly/TestOnlyNrsRetrievalConnectorImpl.scala
@@ -16,18 +16,26 @@
 
 package connectors.testonly
 
+import config.AppConfig
 import connectors.NrsRetrievalConnector
 import models.AuthorisedUser
 import models.testonly.ValidateDownloadResult
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpReads.Implicits.readFromJson
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton
-class TestOnlyNrsRetrievalConnectorImpl @Inject()(nrsRetrievalConnector: NrsRetrievalConnector) extends TestOnlyNrsRetrievalConnector{
+class TestOnlyNrsRetrievalConnectorImpl @Inject()(nrsRetrievalConnector: NrsRetrievalConnector, http: HttpClient)
+                                                 (implicit val appConfig: AppConfig)
+  extends TestOnlyNrsRetrievalConnector {
+
   override def validateDownload(vaultName: String, archiveId: String, user: AuthorisedUser)
                                (implicit hc: HeaderCarrier): Future[ValidateDownloadResult] =
     nrsRetrievalConnector.getSubmissionBundle(vaultName, archiveId, user).map(response => ValidateDownloadResult(response))
+
+  override def checkAuthorisation()(implicit hc: HeaderCarrier): Future[Boolean] =
+    http.GET[Boolean](s"${appConfig.nrsRetrievalUrl}/test-only/check-authorisation")
 }

--- a/app/controllers/testonly/CheckAuthorisationController.scala
+++ b/app/controllers/testonly/CheckAuthorisationController.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testonly
+
+import config.AppConfig
+import connectors.testonly.TestOnlyNrsRetrievalConnector
+import controllers.Stride
+import play.api.Logger
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.error_template
+import views.html.testonly.check_authorisation_page
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@Singleton
+class CheckAuthorisationController @Inject()(override val controllerComponents: MessagesControllerComponents,
+                                             override val authConnector: AuthConnector,
+                                             override val errorPage: error_template,
+                                             connector: TestOnlyNrsRetrievalConnector,
+                                             checkAuthorisationPage: check_authorisation_page)
+                                            (implicit val appConfig: AppConfig)
+  extends FrontendController(controllerComponents) with Stride {
+
+  override val logger: Logger = Logger(this.getClass)
+  override val strideRoles: Set[String] = appConfig.nrsStrideRoles
+
+  val checkAuthorisation: Action[AnyContent] = Action.async { implicit request =>
+      connector.checkAuthorisation().map { status =>
+        Ok(checkAuthorisationPage(s"test-only.check-authorisation.status.200"))
+      }
+  }
+}

--- a/app/controllers/testonly/CheckAuthorisationController.scala
+++ b/app/controllers/testonly/CheckAuthorisationController.scala
@@ -22,6 +22,7 @@ import controllers.Stride
 import play.api.Logger
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.error_template
 import views.html.testonly.check_authorisation_page
@@ -42,8 +43,11 @@ class CheckAuthorisationController @Inject()(override val controllerComponents: 
   override val strideRoles: Set[String] = appConfig.nrsStrideRoles
 
   val checkAuthorisation: Action[AnyContent] = Action.async { implicit request =>
-      connector.checkAuthorisation().map { status =>
-        Ok(checkAuthorisationPage(s"test-only.check-authorisation.status.200"))
+      connector.checkAuthorisation().map { _ =>
+        Ok(checkAuthorisationPage("test-only.check-authorisation.status.200"))
+      }.recover {
+        case e: UpstreamErrorResponse =>
+          Ok(checkAuthorisationPage(s"test-only.check-authorisation.status.${e.statusCode}"))
       }
   }
 }

--- a/app/views/testonly/check_authorisation_page.scala.html
+++ b/app/views/testonly/check_authorisation_page.scala.html
@@ -1,0 +1,27 @@
+@*
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@import config.AppConfig
+@import views.html.components._
+
+@this(layout: Layout, p: Paragraph, textInput: TextInput, h1: Heading1)
+
+@(authorisationStatusMessageKey: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout(pageTitle = Messages("test-only.check-authorisation.page.header"),
+    maybePageHeader = Some(Messages("test-only.check-authorisation.page.header"))) {
+    @p(content = Text(Messages("test-only.check-authorisation.page.info")))
+    @p(content = Text(Messages(authorisationStatusMessageKey)))
+}

--- a/conf/messages
+++ b/conf/messages
@@ -62,5 +62,5 @@ test-only.validate-download.results.headers=Headers
 test-only.check-authorisation.page.header=Test-only check authorisation
 test-only.check-authorisation.page.info=The nrs-retrieval service has determined that your session is:
 test-only.check-authorisation.status.200=Authenticated in Stride and authorised for NRS with the nrs_digital_investigator enrolment.
-test-only.check-authorisation.status.403=Authenticated in Stride but not authorised for NRS with the nrs_digital_investigator enrolment.
 test-only.check-authorisation.status.401=Not authenticated in Stride.
+test-only.check-authorisation.status.403=Authenticated in Stride but not authorised for NRS with the nrs_digital_investigator enrolment.

--- a/conf/messages
+++ b/conf/messages
@@ -57,3 +57,10 @@ test-only.validate-download.results.numberOfZippedBytes=Number of zipped bytes
 test-only.validate-download.results.numberOfZippedFiles=Number of zipped files
 test-only.validate-download.results.files=Files
 test-only.validate-download.results.headers=Headers
+
+################################## Test-only Check Authorisation Page ####################################################
+test-only.check-authorisation.page.header=Test-only check authorisation
+test-only.check-authorisation.page.info=The nrs-retrieval service has determined that your session is:
+test-only.check-authorisation.status.200=Authenticated in Stride and authorised for NRS with the nrs_digital_investigator enrolment.
+test-only.check-authorisation.status.403=Authenticated in Stride but not authorised for NRS with the nrs_digital_investigator enrolment.
+test-only.check-authorisation.status.401=Not authenticated in Stride.

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,6 +10,8 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
+GET /nrs-retrieval/test-only/check-authorisation controllers.testonly.CheckAuthorisationController.checkAuthorisation
+
 GET  /nrs-retrieval/test-only/validate-download controllers.testonly.ValidateDownloadController.showValidateDownload
 POST /nrs-retrieval/test-only/validate-download controllers.testonly.ValidateDownloadController.submitValidateDownload
 

--- a/it/uk/gov/hmrc/nrsretrievalfrontend/TestOnyEndpointsIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrsretrievalfrontend/TestOnyEndpointsIntegrationSpec.scala
@@ -3,6 +3,9 @@ package uk.gov.hmrc.nrsretrievalfrontend
 import play.api.libs.ws.WSResponse
 
 trait TestOnyEndpointsIntegrationSpec extends IntegrationSpec {
+  def checkAuthorisationRequest(): WSResponse =
+    wsClient.url(s"$serviceRoot/test-only/check-authorisation").get.futureValue
+
   def validateDownloadGetRequest(): WSResponse =
     wsClient.url(s"$serviceRoot/test-only/validate-download").get.futureValue
 
@@ -20,6 +23,14 @@ class TestOnyEndpointsEnabledIntegrationSpec extends TestOnyEndpointsIntegration
     response.status shouldBe OK
     response.contentType shouldBe "text/html; charset=UTF-8"
     response.body.contains("Test-only validate download") shouldBe true
+  }
+
+  "GET /nrs-retrieval/test-only/check-authorisation" should {
+    "display the check-authorisation page" when {
+      "the default router is used" in {
+        checkAuthorisationRequest().body should include("Test-only check authorisation")
+      }
+    }
   }
 
   "GET /nrs-retrieval/test-only/validate-download" should {
@@ -41,6 +52,14 @@ class TestOnyEndpointsEnabledIntegrationSpec extends TestOnyEndpointsIntegration
 
 class TestOnyEndpointsDisabledIntegrationSpec extends TestOnyEndpointsIntegrationSpec {
   override val configuration: Map[String, Any] = defaultConfiguration
+
+  "GET /nrs-retrieval/test-only/check-authorisation" should {
+    "return NOT_FOUND" when {
+      "the default router is used" in {
+        checkAuthorisationRequest().status shouldBe NOT_FOUND
+      }
+    }
+  }
 
   "GET /nrs-retrieval/test-only/validate-download" should {
     "return NOT_FOUND" when {

--- a/test/connectors/testonly/TestOnlyNrsRetrievalConnectorSpec.scala
+++ b/test/connectors/testonly/TestOnlyNrsRetrievalConnectorSpec.scala
@@ -24,12 +24,14 @@ import org.mockito.Mockito._
 import org.mockito.internal.stubbing.answers.Returns
 import play.api.libs.ws.WSResponse
 import support.UnitSpec
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.Future
 
 class TestOnlyNrsRetrievalConnectorSpec extends UnitSpec {
   private val nrsConnector = mock[NrsRetrievalConnector]
-  private val connector = new TestOnlyNrsRetrievalConnectorImpl(nrsConnector)
+  private val httpClient = mock[HttpClient]
+  private val connector = new TestOnlyNrsRetrievalConnectorImpl(nrsConnector, httpClient)
   private val aVaultName = "vaultName"
   private val anArchiveId = "archiveId"
   private val user = AuthorisedUser("", "")

--- a/test/connectors/testonly/TestOnlyNrsRetrievalConnectorSpec.scala
+++ b/test/connectors/testonly/TestOnlyNrsRetrievalConnectorSpec.scala
@@ -20,6 +20,7 @@ import akka.util.ByteString
 import connectors.NrsRetrievalConnector
 import models.AuthorisedUser
 import models.testonly.ValidateDownloadResult
+import org.mockito.Matchers.{any, endsWith}
 import org.mockito.Mockito._
 import org.mockito.internal.stubbing.answers.Returns
 import play.api.libs.ws.WSResponse
@@ -48,6 +49,15 @@ class TestOnlyNrsRetrievalConnectorSpec extends UnitSpec {
       await(connector.validateDownload(aVaultName, anArchiveId, user )(hc)) shouldBe expectedResult
 
       verify(nrsConnector).getSubmissionBundle(aVaultName, anArchiveId, user)(hc)
+    }
+  }
+
+  "checkAuthorisation" should {
+    "delegate to the nrs-retrieval endpoint /test-only/check-authorisation" in {
+      when(httpClient.GET(endsWith("/test-only/check-authorisation"), any(), any())(any(), any(), any()))
+        .thenAnswer(new Returns(Future.successful(true)))
+
+      await(connector.checkAuthorisation()) shouldBe true
     }
   }
 }

--- a/test/controllers/testonly/CheckAuthorisationControllerSpec.scala
+++ b/test/controllers/testonly/CheckAuthorisationControllerSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testonly
+
+import connectors.testonly.TestOnlyNrsRetrievalConnector
+import controllers.ControllerSpec
+import org.mockito.Matchers.any
+import org.mockito.Mockito._
+import org.mockito.internal.stubbing.answers.Returns
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.UpstreamErrorResponse
+
+import scala.concurrent.Future
+
+class CheckAuthorisationControllerSpec extends ControllerSpec {
+  private val connector = mock[TestOnlyNrsRetrievalConnector]
+
+  private lazy val controller =
+    new CheckAuthorisationController(
+      stubMessagesControllerComponents(),
+      mockAuthConnector,
+      error_template,
+      connector,
+      injector.instanceOf[views.html.testonly.check_authorisation_page]
+    )
+
+  "checkAuthorisation" should {
+    "confirm that the request is authenticated and authorised" when {
+      "the user is authenticated and authorised" in {
+        doAnswer(new Returns(Future successful true)).when(connector).checkAuthorisation()(any())
+
+        contentAsString(controller.checkAuthorisation(getRequest)) should include("test-only.check-authorisation.status.200")
+      }
+    }
+
+    "confirm that the request is unauthorised" when {
+      "the user is not authenticated" in {
+        doAnswer(new Returns(Future failed UpstreamErrorResponse(UNAUTHORIZED.toString, UNAUTHORIZED)))
+          .when(connector).checkAuthorisation()(any())
+
+        contentAsString(controller.checkAuthorisation(getRequest)) should include("test-only.check-authorisation.status.401")
+      }
+    }
+
+    "confirm that the request is forbidden" when {
+      "the user is authenticated but not authorised" in {
+        doAnswer(new Returns(Future failed UpstreamErrorResponse(FORBIDDEN.toString, FORBIDDEN)))
+          .when(connector).checkAuthorisation()(any())
+
+        contentAsString(controller.checkAuthorisation(getRequest)) should include("test-only.check-authorisation.status.403")
+      }
+    }
+  }
+}


### PR DESCRIPTION
See also: https://github.com/hmrc/nrs-retrieval/pull/41

This adds a test-only endpoint which serves a page which can be used to demonstrate https://github.com/hmrc/nrs-retrieval/pull/41 and also test the functionality when deployed  to MDTP test environments.

```
sbt test
...
[info] ScalaTest
[info] Run completed in 17 seconds, 619 milliseconds.
[info] Total number of tests run: 159
[info] Suites: completed 21, aborted 0
[info] Tests: succeeded 159, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 159, Failed 0, Errors 0, Passed 159
[success] Total time: 20 s, completed 21-Sep-2021 11:47:51
```

```
sbt it:test
...
[info] ScalaTest
[info] Run completed in 29 seconds, 733 milliseconds.
[info] Total number of tests run: 40
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 40, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 40, Failed 0, Errors 0, Passed 40
[success] Total time: 31 s, completed 21-Sep-2021 11:50:06
```

`nrs-retrieval-acceptance-tests`
```
[info] ScalaTest
[info] Run completed in 5 minutes, 49 seconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 30, Failed 0, Errors 0, Passed 30
[success] Total time: 367 s (06:07), completed 21-Sep-2021 11:29:49
```