### PR TITLE
[NONPR-2257] auth enabled and acceptable stride roles must not be con…

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -82,9 +82,6 @@ class AppConfig @Inject()(val runModeConfiguration: Configuration, val environme
 
   Logger.of(classOf[AppConfig]).info(s"Notable events available $notableEvents")
 
-  lazy val nrsStrideRoles: Set[String] = runModeConfiguration.underlying.getStringList("stride.role.names").asScala.toSet
-  lazy val strideAuth: Boolean = runModeConfiguration.getOptional[Boolean]("stride.enabled").getOrElse(false)
   lazy val authHost: String = runModeConfiguration.getOptional[String](s"microservice.services.auth.host").getOrElse("none-authHost")
   lazy val authPort: Int = runModeConfiguration.getOptional[Int](s"microservice.services.auth.port").getOrElse(-1)
-
 }

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -45,18 +45,18 @@ class SearchController @Inject()(@Named("retrieval-actor") retrievalActor: Actor
                                  val nrsRetrievalConnector: NrsRetrievalConnector,
                                  val searchResultUtils: SearchResultUtils,
                                  override val controllerComponents: MessagesControllerComponents,
+                                 override val strideAuthSettings: StrideAuthSettings,
                                  val searchPage: search_page,
                                  override val errorPage: error_template)
                                 (implicit val appConfig: AppConfig)
   extends FrontendController(controllerComponents) with I18nSupport with Stride {
 
   override val logger: Logger = Logger(this.getClass)
-  override val strideRoles: Set[String] = appConfig.nrsStrideRoles
   override lazy val parse: PlayBodyParsers = controllerComponents.parsers
 
   implicit val timeout: Timeout = Timeout(FiniteDuration(appConfig.futureTimeoutSeconds, TimeUnit.SECONDS))
 
-  def noParameters(): Action[AnyContent] = Action.async { implicit request =>
+  val noParameters: Action[AnyContent] = Action.async { implicit request =>
     logger.info(s"No parameters provided so redirecting to start page on request $request")
     Future(Redirect(routes.StartController.showStartPage()))
   }

--- a/app/controllers/SelectorController.scala
+++ b/app/controllers/SelectorController.scala
@@ -32,20 +32,18 @@ import scala.concurrent.Future
 @Singleton
 class SelectorController @Inject()(val authConnector: AuthConnector,
                                    override val controllerComponents: MessagesControllerComponents,
+                                   override val strideAuthSettings: StrideAuthSettings,
                                    val selectorPage: selector_page,
                                    override val errorPage: error_template)
                                   (implicit val appConfig: AppConfig)
   extends FrontendController(controllerComponents) with I18nSupport with Stride {
 
   override val logger: Logger = Logger(this.getClass)
-  override val strideRoles: Set[String] = appConfig.nrsStrideRoles
   override lazy val parse: PlayBodyParsers = controllerComponents.parsers
 
-  logger.info(s"appConfig: stride.enabled: ${appConfig.strideAuth}")
-  logger.info(s"appConfig: stride.role.name: $strideRoles")
   logger.info(s"appConfig: auth host:port: ${appConfig.authHost}:${appConfig.authPort}")
 
-  def showSelectorPage: Action[AnyContent] = Action.async { implicit request =>
+  val showSelectorPage: Action[AnyContent] = Action.async { implicit request =>
     authWithStride("Show the selector page", { nrUser =>
       Future.successful(
         Ok(selectorPage(selectorForm, Some(nrUser)))
@@ -53,7 +51,7 @@ class SelectorController @Inject()(val authConnector: AuthConnector,
     })
   }
 
-  def submitSelectorPage: Action[AnyContent] = Action.async { implicit request =>
+  val submitSelectorPage: Action[AnyContent] = Action.async { implicit request =>
     authWithStride("Submit the selector page", { nrUser =>
       selectorForm.bindFromRequest.fold(
         formWithErrors => {

--- a/app/controllers/StartController.scala
+++ b/app/controllers/StartController.scala
@@ -31,27 +31,23 @@ import scala.concurrent.Future
 @Singleton
 class StartController @Inject()(val authConnector: AuthConnector,
                                 override val controllerComponents: MessagesControllerComponents,
+                                override val strideAuthSettings: StrideAuthSettings,
                                 val startPage: start_page,
                                 override val errorPage: error_template)
                                (implicit val appConfig: AppConfig) extends FrontendController(controllerComponents)
   with I18nSupport with Stride {
 
   override val logger: Logger = Logger(this.getClass)
-  override val strideRoles: Set[String] = appConfig.nrsStrideRoles
   override lazy val parse: PlayBodyParsers = controllerComponents.parsers
 
-  logger.info(s"appConfig: stride.enabled: ${appConfig.strideAuth}")
-  logger.info(s"appConfig: stride.role.name: $strideRoles")
   logger.info(s"appConfig: auth host:port: ${appConfig.authHost}:${appConfig.authPort}")
 
-  def showStartPage: Action[AnyContent] = Action.async { implicit request =>
+  val showStartPage: Action[AnyContent] = Action.async { implicit request =>
     logger.info(s"S=how start page")
     authWithStride("Show the start page", { _ =>
       Future.successful(
         Ok(startPage())
       )
     })
-
   }
-
 }

--- a/app/controllers/testonly/CheckAuthorisationController.scala
+++ b/app/controllers/testonly/CheckAuthorisationController.scala
@@ -18,7 +18,7 @@ package controllers.testonly
 
 import config.AppConfig
 import connectors.testonly.TestOnlyNrsRetrievalConnector
-import controllers.Stride
+import controllers.{Stride, StrideAuthSettings}
 import play.api.Logger
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -33,6 +33,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 @Singleton
 class CheckAuthorisationController @Inject()(override val controllerComponents: MessagesControllerComponents,
                                              override val authConnector: AuthConnector,
+                                             override val strideAuthSettings: StrideAuthSettings,
                                              override val errorPage: error_template,
                                              connector: TestOnlyNrsRetrievalConnector,
                                              checkAuthorisationPage: check_authorisation_page)
@@ -40,7 +41,6 @@ class CheckAuthorisationController @Inject()(override val controllerComponents: 
   extends FrontendController(controllerComponents) with Stride {
 
   override val logger: Logger = Logger(this.getClass)
-  override val strideRoles: Set[String] = appConfig.nrsStrideRoles
 
   val checkAuthorisation: Action[AnyContent] = Action.async { implicit request =>
       connector.checkAuthorisation().map { _ =>

--- a/app/controllers/testonly/ValidateDownloadController.scala
+++ b/app/controllers/testonly/ValidateDownloadController.scala
@@ -18,7 +18,7 @@ package controllers.testonly
 
 import config.AppConfig
 import connectors.testonly.TestOnlyNrsRetrievalConnector
-import controllers.Stride
+import controllers.{Stride, StrideAuthSettings}
 import controllers.testonly.FormMappings.validateDownloadForm
 import play.api.Logger
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, RequestHeader}
@@ -35,6 +35,7 @@ import scala.concurrent.Future
 @Singleton
 class ValidateDownloadController @Inject()(override val controllerComponents: MessagesControllerComponents,
                                            override val authConnector: AuthConnector,
+                                           override val strideAuthSettings: StrideAuthSettings,
                                            override val errorPage: error_template,
                                            connector: TestOnlyNrsRetrievalConnector,
                                            validateDownloadPage: validate_download_page)
@@ -42,12 +43,11 @@ class ValidateDownloadController @Inject()(override val controllerComponents: Me
   extends FrontendController(controllerComponents) with Stride {
 
   override val logger: Logger = Logger(this.getClass)
-  override val strideRoles: Set[String] = appConfig.nrsStrideRoles
 
   private val authAction = "Validate download"
 
-  implicit override def hc(implicit rh: RequestHeader): HeaderCarrier = super.hc
-    .withExtraHeaders("X-API-Key" -> appConfig.xApiKey)
+  implicit override def hc(implicit rh: RequestHeader): HeaderCarrier =
+    super.hc.withExtraHeaders("X-API-Key" -> appConfig.xApiKey)
 
   val showValidateDownload: Action[AnyContent] = Action.async { implicit request =>
     authWithStride(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -127,11 +127,6 @@ polling {
   interval = 5000
 }
 
-stride {
-  enabled = true
-  role.names = ["nrs digital investigator", "nrs_digital_investigator"]
-}
-
 notableEvents = [
   {
     notableEvent = "vat-return"

--- a/it/uk/gov/hmrc/nrsretrievalfrontend/IntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrsretrievalfrontend/IntegrationSpec.scala
@@ -17,15 +17,16 @@
 package uk.gov.hmrc.nrsretrievalfrontend
 
 import com.github.tomakehurst.wiremock.client.WireMock
+import controllers.StrideAuthSettings
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.Injector
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.{Binding, Injector, Module}
 import play.api.libs.ws.WSClient
+import play.api.{Application, Configuration, Environment, inject}
 import uk.gov.hmrc.nrsretrievalfrontend.wiremock.WireMockSupport
 
 trait IntegrationSpec extends AnyWordSpec
@@ -38,7 +39,18 @@ trait IntegrationSpec extends AnyWordSpec
   with Fixture {
   override def beforeEach(): Unit = WireMock.reset()
 
-  override def fakeApplication(): Application = new GuiceApplicationBuilder().configure(configuration).build()
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder(
+      modules =
+        Seq(
+          new Module() {
+            override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =
+              Seq(inject.bind[StrideAuthSettings].to[StrideAuthIsDisabled])
+          }
+        )
+    )
+    .configure(configuration)
+    .build()
 
   val defaultConfiguration: Map[String, Any] = Map[String, Any](
     "microservice.services.nrs-retrieval.port" -> wireMockPort,
@@ -52,4 +64,8 @@ trait IntegrationSpec extends AnyWordSpec
   lazy val wsClient: WSClient = injector.instanceOf[WSClient]
 
   lazy val serviceRoot = s"http://localhost:$port/nrs-retrieval"
+}
+
+class StrideAuthIsDisabled extends StrideAuthSettings {
+  override val strideAuthEnabled: Boolean = false
 }

--- a/it/uk/gov/hmrc/nrsretrievalfrontend/IntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrsretrievalfrontend/IntegrationSpec.scala
@@ -55,8 +55,7 @@ trait IntegrationSpec extends AnyWordSpec
   val defaultConfiguration: Map[String, Any] = Map[String, Any](
     "microservice.services.nrs-retrieval.port" -> wireMockPort,
     "auditing.enabled" -> false,
-    "metrics.jvm" -> false,
-    "stride.enabled" -> false)
+    "metrics.jvm" -> false)
 
   def configuration: Map[String, Any] = defaultConfiguration
 

--- a/test/controllers/ControllerSpec.scala
+++ b/test/controllers/ControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import config.AppConfig
 import org.jsoup.Jsoup.parse
 import org.jsoup.nodes.Document
 import org.mockito.Matchers.any
@@ -26,11 +25,9 @@ import org.mockito.stubbing.OngoingStubbing
 import play.api.mvc.{AnyContentAsEmpty, Result}
 import play.api.test.Helpers.{contentAsString, status, _}
 import play.api.test.{FakeRequest, StubControllerComponentsFactory}
-import play.api.{Configuration, Environment}
 import support.GuiceAppSpec
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, EmptyRetrieval, Name}
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, Enrolments, retrieve}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import views.html.error_template
 
 import scala.concurrent.Future
@@ -39,7 +36,6 @@ trait ControllerSpec extends GuiceAppSpec with StubControllerComponentsFactory {
   val getRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
   val emptyPostRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("POST", "/")
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
-  val authEnabledAppConfig: AuthEnabledAppConfig = new AuthEnabledAppConfig(configuration, environment, servicesConfig)
 
   lazy val error_template: error_template = injector.instanceOf[error_template]
 
@@ -70,11 +66,4 @@ trait ControllerSpec extends GuiceAppSpec with StubControllerComponentsFactory {
 
   def theNotAuthorisedPageShouldBeRendered(eventualResult: Future[Result]): Document =
     aPageShouldBeRendered(eventualResult,"Not authorised" )
-
-}
-
-class AuthEnabledAppConfig(runModeConfiguration: Configuration, environment: Environment, servicesConfig: ServicesConfig)
-  extends AppConfig(runModeConfiguration, environment, servicesConfig) {
-
-  override lazy val strideAuth: Boolean = true
 }

--- a/test/controllers/SelectorControllerSpec.scala
+++ b/test/controllers/SelectorControllerSpec.scala
@@ -27,27 +27,27 @@ import scala.concurrent.Future
 class SelectorControllerSpec extends ControllerSpec {
   private def selectorController(implicit appConfig: AppConfig) =
     new SelectorController(
-      mockAuthConnector, stubMessagesControllerComponents(), injector.instanceOf[selector_page], error_template)
+      mockAuthConnector,
+      stubMessagesControllerComponents(),
+      new StrideAuthSettings(),
+      injector.instanceOf[selector_page],
+      error_template)
 
   "showSelectorPage" should {
     def theSelectorPageShouldBeRendered(eventualResult: Future[Result]) =
       aPageShouldBeRendered(eventualResult, "selector.page.header.lbl")
 
     "return 200 and render the selector page" when {
-      "auth is disabled" in {
-        theSelectorPageShouldBeRendered(selectorController(appConfig).showSelectorPage(getRequest))
-      }
-
-      "auth is enabled and the request is authorised" in {
+      "the request is authorised" in {
         givenTheRequestIsAuthorised()
-        theSelectorPageShouldBeRendered(selectorController(authEnabledAppConfig).showSelectorPage(getRequest))
+        theSelectorPageShouldBeRendered(selectorController(appConfig).showSelectorPage(getRequest))
       }
     }
 
     "return OK and render the error page" when {
-      "auth is enabled and the request is unauthorised" in {
+      "the request is unauthorised" in {
         givenTheRequestIsUnauthorised()
-        theNotAuthorisedPageShouldBeRendered(selectorController(authEnabledAppConfig).showSelectorPage(getRequest))
+        theNotAuthorisedPageShouldBeRendered(selectorController(appConfig).showSelectorPage(getRequest))
       }
     }
   }
@@ -64,15 +64,10 @@ class SelectorControllerSpec extends ControllerSpec {
             Map("Location" -> controllers.routes.SearchController.showSearchPage(notableEventType).url)
         }
 
-        s"auth is disabled and the notable event type $notableEventType is selected" in {
-          theRequestShouldBeRedirectedToTheSearchPage(
-            selectorController(appConfig).submitSelectorPage(postRequestWithNotableEventType))
-        }
-
-        s"auth is enabled and the request is authorised and the notable event type $notableEventType is selected" in {
+        s"and the request is authorised and the notable event type $notableEventType is selected" in {
           givenTheRequestIsAuthorised()
           theRequestShouldBeRedirectedToTheSearchPage(
-            selectorController(authEnabledAppConfig).submitSelectorPage(postRequestWithNotableEventType))
+            selectorController(appConfig).submitSelectorPage(postRequestWithNotableEventType))
         }
       }
     }
@@ -81,22 +76,17 @@ class SelectorControllerSpec extends ControllerSpec {
       def theSelectorPageShouldBeRenderedWithAnErrorMessage(eventualResult: Future[Result]) =
         aPageShouldBeRendered(eventualResult, "generic.errorPrefix selector.page.header.lbl")
 
-      "auth is disabled and no notable event type is selected" in {
-        theSelectorPageShouldBeRenderedWithAnErrorMessage(
-          selectorController(appConfig).submitSelectorPage(emptyPostRequest))
-      }
-
-      "auth is enabled and the request is authorised and no notable event type is selected" in {
+      "and the request is authorised and no notable event type is selected" in {
         givenTheRequestIsAuthorised()
         theSelectorPageShouldBeRenderedWithAnErrorMessage(
-          selectorController(authEnabledAppConfig).submitSelectorPage(emptyPostRequest))
+          selectorController(appConfig).submitSelectorPage(emptyPostRequest))
       }
     }
 
     "return OK and render the error page" when {
-      "auth is enabled and the request is unauthorised" in {
+      "and the request is unauthorised" in {
         givenTheRequestIsUnauthorised()
-        theNotAuthorisedPageShouldBeRendered(selectorController(authEnabledAppConfig).submitSelectorPage(emptyPostRequest))
+        theNotAuthorisedPageShouldBeRendered(selectorController(appConfig).submitSelectorPage(emptyPostRequest))
       }
     }
   }

--- a/test/controllers/StartControllerSpec.scala
+++ b/test/controllers/StartControllerSpec.scala
@@ -25,27 +25,26 @@ import scala.concurrent.Future
 class StartControllerSpec extends ControllerSpec {
   private def startController(implicit appConfig: AppConfig) =
     new StartController(
-      mockAuthConnector, stubMessagesControllerComponents(), injector.instanceOf[start_page], error_template)
+      mockAuthConnector,
+      stubMessagesControllerComponents(),
+      new StrideAuthSettings(),
+      injector.instanceOf[start_page], error_template)
 
   "showStartPage" should {
     "return 200 and render the start page" when {
       def theStartPageShouldBeRendered(eventualResult: Future[Result]) =
         aPageShouldBeRendered(eventualResult, "start.page.header.lbl")
 
-      "auth is disabled" in {
-        theStartPageShouldBeRendered(startController(appConfig).showStartPage(getRequest))
-      }
-
-      "auth is enabled and the request is authorised" in {
+      "the request is authorised" in {
         givenTheRequestIsAuthorised()
-        theStartPageShouldBeRendered(startController(authEnabledAppConfig).showStartPage(getRequest))
+        theStartPageShouldBeRendered(startController(appConfig).showStartPage(getRequest))
       }
     }
 
     "return OK and render the error page" when {
-      "auth is enabled and the request is unauthorised" in {
+      "the request is unauthorised" in {
         givenTheRequestIsUnauthorised()
-        theNotAuthorisedPageShouldBeRendered(startController(authEnabledAppConfig).showStartPage(getRequest))
+        theNotAuthorisedPageShouldBeRendered(startController(appConfig).showStartPage(getRequest))
       }
     }
   }

--- a/test/controllers/StrideAuthSettingsSpec.scala
+++ b/test/controllers/StrideAuthSettingsSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import support.UnitSpec
+
+class StrideAuthSettingsSpec extends UnitSpec {
+  private val settings = new StrideAuthSettings()
+  
+  "strideAuthEnabled" should {
+    "be true" in {
+      settings.strideAuthEnabled shouldBe true
+    }
+  }
+
+  "strideRoles" should {
+    """be "nrs digital investigator" and "nrs_digital_investigator" """ in {
+      settings.strideRoles shouldBe Set("nrs digital investigator", "nrs_digital_investigator")
+    }
+  }
+}

--- a/test/controllers/testonly/CheckAuthorisationControllerSpec.scala
+++ b/test/controllers/testonly/CheckAuthorisationControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.testonly
 
 import connectors.testonly.TestOnlyNrsRetrievalConnector
-import controllers.ControllerSpec
+import controllers.{ControllerSpec, StrideAuthSettings}
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.mockito.internal.stubbing.answers.Returns
@@ -33,6 +33,7 @@ class CheckAuthorisationControllerSpec extends ControllerSpec {
     new CheckAuthorisationController(
       stubMessagesControllerComponents(),
       mockAuthConnector,
+      new StrideAuthSettings(),
       error_template,
       connector,
       injector.instanceOf[views.html.testonly.check_authorisation_page]

--- a/test/controllers/testonly/ValidateDownloadControllerSpec.scala
+++ b/test/controllers/testonly/ValidateDownloadControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.testonly
 
 import connectors.testonly.TestOnlyNrsRetrievalConnector
-import controllers.ControllerSpec
+import controllers.{ControllerSpec, StrideAuthSettings}
 import controllers.testonly.FormMappings.{archiveId, vaultName}
 import models.testonly.ValidateDownloadResult
 import org.jsoup.Jsoup
@@ -37,6 +37,7 @@ class ValidateDownloadControllerSpec extends ControllerSpec {
     new ValidateDownloadController(
       stubMessagesControllerComponents(),
       mockAuthConnector,
+      new StrideAuthSettings(),
       error_template,
       connector,
       injector.instanceOf[views.html.testonly.validate_download_page]
@@ -60,6 +61,7 @@ class ValidateDownloadControllerSpec extends ControllerSpec {
 
   "showValidateDownload" should {
     "display the validate download page" in {
+      givenTheRequestIsAuthorised()
       validateResponse(controller.showValidateDownload(getRequest))
     }
   }
@@ -74,6 +76,8 @@ class ValidateDownloadControllerSpec extends ControllerSpec {
       val files = Seq(file1, file2)
       val header1 = ("header1", "h1")
       val header2 = ("header2", "h2")
+
+      givenTheRequestIsAuthorised()
 
       when(connector.validateDownload(Matchers.eq(aVaultName), Matchers.eq(anArchiveId), any())(any()))
         .thenReturn(Future successful ValidateDownloadResult(OK, zipSize, files, Seq(header1, header2)))

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -13,7 +13,3 @@
 # limitations under the License.
 
 metrics.enabled = false
-
-stride {
-  enabled = false
-}


### PR DESCRIPTION
…figurable.

This simplifies auth because the behaviour is defined entirely within the service rather than being configured and so potentially different between environments. 

It also prevents accidental or malicious misconfiguration from turning auth off in production where our tests don't run.

```
sbt test 
...
[info] ScalaTest
[info] Run completed in 15 seconds, 258 milliseconds.
[info] Total number of tests run: 185
[info] Suites: completed 22, aborted 0
[info] Tests: succeeded 185, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 185, Failed 0, Errors 0, Passed 185
[success] Total time: 17 s, completed 4 May 2022, 07:31:36
```

```
sbt it:test
...
[info] ScalaTest
[info] Run completed in 28 seconds, 646 milliseconds.
[info] Total number of tests run: 41
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 41, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 41, Failed 0, Errors 0, Passed 41
[success] Total time: 30 s, completed 4 May 2022, 07:32:48
```

acceptance tests:
```
[info] ScalaTest
[info] Run completed in 6 minutes, 43 seconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 44, Failed 0, Errors 0, Passed 44
[success] Total time: 419 s (06:59), completed 3 May 2022, 17:06:07
```

Note that if `StrideAuthSettings.strideAuthEnabled` is changed to false then unit and acceptance tests will fail. 